### PR TITLE
Improve C coverage and filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,18 @@ LDFLAGS?=-lpcap
 filter: main.c
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
+test: CFLAGS+=--coverage -O0
+test: LDFLAGS+=--coverage
+
 test: filter
 	coverage run -m pytest -v
+	coverage html -d pycov
 	coverage report -m
+	lcov --capture --directory . --output-file c_cov.info
+	genhtml c_cov.info --output-directory c_html > /dev/null
 
 clean:
-	rm -f filter
+	rm -f filter *.gcno *.gcda c_cov.info
+	rm -rf pycov c_html
 
 .PHONY: test clean


### PR DESCRIPTION
## Summary
- generate lcov coverage and html output
- reduce comments and sanity checks in `build_and_filter`
- write filter results to a binary file instead of stdout
- update tests for the new interface and add a zero‑whitelist case

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6851681465c883208419340d70819495