### PR TITLE
Run filter per packet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# build artifacts
+filter
+*.gcda
+*.gcno
+
+# coverage output
+.cov*
+coverage*
+.c_cov.info
+c_cov.info
+c_html/
+.pycov/
+.coverage
+
+# python cache
+__pycache__/
+tests/__pycache__/
+
+# temporary files
+*.pcap


### PR DESCRIPTION
## Summary
- make `run_filter` handle single packets and loop in tests
- keep exit-code mode for per-packet runs

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68516c0556e883209e7d2cd71e1f34b5