### PR TITLE
Reset registers and enforce BPF size

### DIFF
--- a/whitelist.c
+++ b/whitelist.c
@@ -1,6 +1,7 @@
 #include "whitelist.h"
 #include <stdlib.h>
 #include <string.h>
+#include <linux/bpf_common.h>
 
 #define SRC_IP_OFFSET 26
 
@@ -10,8 +11,21 @@ struct bpf_insn *append_ip_whitelist(const struct bpf_insn *orig,
                                      size_t n_ips,
                                      unsigned *out_len)
 {
-    const unsigned whitelist_insn_count = 1 + n_ips + 1;
+    unsigned whitelist_insn_count = 0;
+
+    /* load src ip */
+    whitelist_insn_count++;
+    /* compare against allowed ips */
+    whitelist_insn_count += n_ips;
+    /* drop packet if not matched */
+    whitelist_insn_count++;
+    /* reset A and X registers */
+    whitelist_insn_count += 2;
+
     const unsigned total_len = whitelist_insn_count + orig_len;
+
+    if (total_len > BPF_MAXINSNS)
+        return NULL;
 
     struct bpf_insn *prog = malloc(total_len * sizeof(*prog));
     if (!prog)
@@ -27,6 +41,8 @@ struct bpf_insn *append_ip_whitelist(const struct bpf_insn *orig,
                                               ips[idx], jt, 0);
     }
     prog[i++] = (struct bpf_insn)BPF_STMT(BPF_RET | BPF_K, 0);
+    prog[i++] = (struct bpf_insn)BPF_STMT(BPF_LD | BPF_W | BPF_IMM, 0);
+    prog[i++] = (struct bpf_insn)BPF_STMT(BPF_LDX | BPF_IMM, 0);
 
     memcpy(&prog[i], orig, orig_len * sizeof(*orig));
     i += orig_len;


### PR DESCRIPTION
## Summary
- reset the BPF `A` and `X` registers after checking source IPs
- verify that the generated program does not exceed `BPF_MAXINSNS`
- compute the whitelist length dynamically so future changes don't require manual updates

## Testing
- `make clean`
- `make filter`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852d54b14188320891f7bff62f3fcdc